### PR TITLE
Added edge cost calculation to route vertex

### DIFF
--- a/include/Route.hpp
+++ b/include/Route.hpp
@@ -9,9 +9,10 @@ class Route {
 	public:
 		int capacity;
 		int maxSize;
-		int currentVertexId;
+		Vertex currentVertex;
 		std::list<Vertex> route[MAX_SIZE];
-		Route(int maxSize, int capacity);
+		
+		Route(Vertex depot, int maxSize, int capacity);
 		void addVertexToRoute(Vertex v);
 };
 

--- a/include/Vertex.hpp
+++ b/include/Vertex.hpp
@@ -3,7 +3,9 @@
 class Vertex {
 	public:
 		int id;
-		float demand;
+		float demand, cost;
 		int x, y;
+
 		Vertex(int id, int x, int y, float demand);
+		Vertex();
 };

--- a/src/Heuristics.cpp
+++ b/src/Heuristics.cpp
@@ -30,7 +30,7 @@ std::vector<Route> Heuristics::binPacking(std::vector<Vertex> vertices, int maxC
 
     std::sort(vertices.begin(), vertices.end(), compare);
     do {
-        Route r = Route(size, maxCapacity);
+        Route r = Route(depot, size, maxCapacity);
         auto it = vertices.begin();
         while( (it != vertices.end()) || (r.capacity == 0) ) {
             if(r.capacity > it->demand) {

--- a/src/Route.cpp
+++ b/src/Route.cpp
@@ -1,18 +1,25 @@
+#include <cmath>
+
 #include "../include/Route.hpp"
-#include "../include/Vertex.hpp"
 
 using namespace std;
 
-Route::Route(int maxSize, int capacity) {
+Route::Route(Vertex depot, int maxSize, int capacity) {
     this->capacity = capacity;
     this->maxSize = maxSize;
-    this->currentVertexId = 1;
+    this->currentVertex = depot;
 }
 
 
 void Route::addVertexToRoute(Vertex v) {
-    this->route[this->currentVertexId].push_back(v);
-    this->currentVertexId = v.id;
+    /** Edge calculation - cost associated with edge ending at this vertex **/
+    v.cost = sqrt(pow(this->currentVertex.x - v.x, 2.0) + pow(this->currentVertex.y - v.y, 2.0));
+
+    int id = this->currentVertex.id;
+    this->route[id].push_back(v);
+    this->currentVertex = v;
 }
+
+
 
 

--- a/src/Vertex.cpp
+++ b/src/Vertex.cpp
@@ -5,4 +5,13 @@ Vertex::Vertex(int id, int x, int y, float demand) {
     this->x = x;
     this->y = y;
     this->demand = demand;
+    this->cost = 0.0;
+}
+
+Vertex::Vertex() {
+    this->id = -1;
+    this->x = -1;
+    this->y = -1;
+    this->demand = -1;
+    this->cost = 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@ int main() {
     cout << "VRP - Vertex Description: " << endl;
     float totalDemand = 0.0;
     for (size_t i = 0; i < vertices.size(); i++) {
-        Vertex vertex = vertices.at(i);
+        Vertex vertex = vertices[i];
         cout << vertex.id << " @ " << "(" << vertex.x << ", " << vertex.y << ")" << " : " << vertex.demand << endl;    
     
         totalDemand += vertex.demand;
@@ -38,16 +38,20 @@ int main() {
         Route r = sol[i];
         
         // Print routes for Bin Packing heuristics
-        cout << "Route " << i << " :   ";
         int vertexId = 1;
-        cout << vertexId << "  ";
+        float cost = 0;
+
+        cout << "Route " << i << " :   " << vertexId << "  ";
         do {
             auto it = r.route[vertexId].begin();
             cout << it->id << "  ";
             vertexId = it->id;
+            cost += it->cost;
         } while(vertexId != 1);
-        cout << " - cap: " << capacity - r.capacity << endl;
+        cout << "- cap: " << capacity - r.capacity << " - cost: " << cost << endl;
     }
+
+    /** Next step: Neighbourhood Search -> Inter and Intra Route Local Search **/
 
     return 0;
 }


### PR DESCRIPTION
Route now stores current vertex instead of vertex id.
Each vertex from a route has a cost attribute that associates them to a previous vertex (represented by the index in the route array).